### PR TITLE
Store attribute constructor parameters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,14 +20,14 @@
         "php": ">=8.1"
     },
     "require-dev": {
-        "php-static-analysis/node-visitor": "^0.4.1 || dev-main",
-        "php-static-analysis/phpstan-extension": "^0.4.1 || dev-main",
-        "php-static-analysis/psalm-plugin": "^0.4.1 || dev-main",
+        "php-static-analysis/node-visitor": "^0.5.0 || dev-main",
+        "php-static-analysis/phpstan-extension": "^0.5.0 || dev-main",
+        "php-static-analysis/psalm-plugin": "^0.5.0 || dev-main",
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan": "^2.0",
         "phpunit/phpunit": "^9.0",
         "symplify/easy-coding-standard": "^12.1",
-        "vimeo/psalm": "^6"
+        "vimeo/psalm": "^6.12"
     },
     "scripts": {
         "phpstan": "phpstan analyse",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -32,10 +32,6 @@ parameters:
             paths:
                 - tests/AssertIfTrueTest.php
 
-        -
-            identifier: constructor.unusedParameter
-            paths:
-                - src/*
 
         -
             identifier: missingType.iterableValue

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -14,8 +14,13 @@ use Attribute;
 )]
 final class Assert
 {
-    public function __construct(
-        string ...$params
-    ) {
+    /**
+     * @var string[]
+     */
+    public readonly array $params;
+
+    public function __construct(string ...$params)
+    {
+        $this->params = $params;
     }
 }

--- a/src/AssertIfFalse.php
+++ b/src/AssertIfFalse.php
@@ -14,8 +14,13 @@ use Attribute;
 )]
 final class AssertIfFalse
 {
-    public function __construct(
-        string ...$params
-    ) {
+    /**
+     * @var string[]
+     */
+    public readonly array $params;
+
+    public function __construct(string ...$params)
+    {
+        $this->params = $params;
     }
 }

--- a/src/AssertIfTrue.php
+++ b/src/AssertIfTrue.php
@@ -14,8 +14,13 @@ use Attribute;
 )]
 final class AssertIfTrue
 {
-    public function __construct(
-        string ...$params
-    ) {
+    /**
+     * @var string[]
+     */
+    public readonly array $params;
+
+    public function __construct(string ...$params)
+    {
+        $this->params = $params;
     }
 }

--- a/src/DefineType.php
+++ b/src/DefineType.php
@@ -12,8 +12,13 @@ use Attribute;
 )]
 final class DefineType
 {
-    public function __construct(
-        string ...$types
-    ) {
+    /**
+     * @var string[]
+     */
+    public readonly array $types;
+
+    public function __construct(string ...$types)
+    {
+        $this->types = $types;
     }
 }

--- a/src/ImportType.php
+++ b/src/ImportType.php
@@ -12,8 +12,13 @@ use Attribute;
 )]
 final class ImportType
 {
-    public function __construct(
-        string ...$from
-    ) {
+    /**
+     * @var string[]
+     */
+    public readonly array $from;
+
+    public function __construct(string ...$from)
+    {
+        $this->from = $from;
     }
 }

--- a/src/Internal.php
+++ b/src/Internal.php
@@ -15,8 +15,7 @@ use Attribute;
 )]
 final class Internal
 {
-    public function __construct(
-        ?string $namespace = null
-    ) {
+    public function __construct(public readonly ?string $namespace = null)
+    {
     }
 }

--- a/src/Method.php
+++ b/src/Method.php
@@ -12,8 +12,13 @@ use Attribute;
 )]
 final class Method
 {
-    public function __construct(
-        string ...$methods
-    ) {
+    /**
+     * @var string[]
+     */
+    public readonly array $methods;
+
+    public function __construct(string ...$methods)
+    {
+        $this->methods = $methods;
     }
 }

--- a/src/Mixin.php
+++ b/src/Mixin.php
@@ -12,8 +12,13 @@ use Attribute;
 )]
 final class Mixin
 {
-    public function __construct(
-        string ...$classes
-    ) {
+    /**
+     * @var string[]
+     */
+    public readonly array $classes;
+
+    public function __construct(string ...$classes)
+    {
+        $this->classes = $classes;
     }
 }

--- a/src/Param.php
+++ b/src/Param.php
@@ -14,8 +14,13 @@ use Attribute;
 )]
 final class Param
 {
-    public function __construct(
-        string ...$params
-    ) {
+    /**
+     * @var string[]
+     */
+    public readonly array $params;
+
+    public function __construct(string ...$params)
+    {
+        $this->params = $params;
     }
 }

--- a/src/ParamOut.php
+++ b/src/ParamOut.php
@@ -14,8 +14,13 @@ use Attribute;
 )]
 final class ParamOut
 {
-    public function __construct(
-        string ...$params
-    ) {
+    /**
+     * @var string[]
+     */
+    public readonly array $params;
+
+    public function __construct(string ...$params)
+    {
+        $this->params = $params;
     }
 }

--- a/src/Property.php
+++ b/src/Property.php
@@ -13,8 +13,13 @@ use Attribute;
 )]
 final class Property
 {
-    public function __construct(
-        string ...$properties
-    ) {
+    /**
+     * @var string[]
+     */
+    public readonly array $properties;
+
+    public function __construct(string ...$properties)
+    {
+        $this->properties = $properties;
     }
 }

--- a/src/PropertyRead.php
+++ b/src/PropertyRead.php
@@ -12,8 +12,13 @@ use Attribute;
 )]
 final class PropertyRead
 {
-    public function __construct(
-        string ...$properties
-    ) {
+    /**
+     * @var string[]
+     */
+    public readonly array $properties;
+
+    public function __construct(string ...$properties)
+    {
+        $this->properties = $properties;
     }
 }

--- a/src/PropertyWrite.php
+++ b/src/PropertyWrite.php
@@ -12,8 +12,13 @@ use Attribute;
 )]
 final class PropertyWrite
 {
-    public function __construct(
-        string ...$properties
-    ) {
+    /**
+     * @var string[]
+     */
+    public readonly array $properties;
+
+    public function __construct(string ...$properties)
+    {
+        $this->properties = $properties;
     }
 }

--- a/src/RequireExtends.php
+++ b/src/RequireExtends.php
@@ -11,8 +11,7 @@ use Attribute;
 )]
 final class RequireExtends
 {
-    public function __construct(
-        string $class
-    ) {
+    public function __construct(public readonly string $class)
+    {
     }
 }

--- a/src/RequireImplements.php
+++ b/src/RequireImplements.php
@@ -12,8 +12,13 @@ use Attribute;
 )]
 final class RequireImplements
 {
-    public function __construct(
-        string ...$interfaces
-    ) {
+    /**
+     * @var string[]
+     */
+    public readonly array $interfaces;
+
+    public function __construct(string ...$interfaces)
+    {
+        $this->interfaces = $interfaces;
     }
 }

--- a/src/Returns.php
+++ b/src/Returns.php
@@ -12,8 +12,7 @@ use Attribute;
 )]
 final class Returns
 {
-    public function __construct(
-        string $type
-    ) {
+    public function __construct(public readonly string $type)
+    {
     }
 }

--- a/src/SelfOut.php
+++ b/src/SelfOut.php
@@ -11,8 +11,7 @@ use Attribute;
 )]
 final class SelfOut
 {
-    public function __construct(
-        string $type
-    ) {
+    public function __construct(public readonly string $type)
+    {
     }
 }

--- a/src/Template.php
+++ b/src/Template.php
@@ -15,8 +15,8 @@ use Attribute;
 final class Template
 {
     public function __construct(
-        string $name,
-        ?string $of = null
+        public readonly string $name,
+        public readonly ?string $of = null,
     ) {
     }
 }

--- a/src/TemplateContravariant.php
+++ b/src/TemplateContravariant.php
@@ -13,8 +13,8 @@ use Attribute;
 final class TemplateContravariant
 {
     public function __construct(
-        string $name,
-        ?string $of = null
+        public readonly string $name,
+        public readonly ?string $of = null,
     ) {
     }
 }

--- a/src/TemplateCovariant.php
+++ b/src/TemplateCovariant.php
@@ -13,8 +13,8 @@ use Attribute;
 final class TemplateCovariant
 {
     public function __construct(
-        string $name,
-        ?string $of = null
+        public readonly string $name,
+        public readonly ?string $of = null,
     ) {
     }
 }

--- a/src/TemplateExtends.php
+++ b/src/TemplateExtends.php
@@ -11,8 +11,7 @@ use Attribute;
 )]
 final class TemplateExtends
 {
-    public function __construct(
-        string $class
-    ) {
+    public function __construct(public readonly string $class)
+    {
     }
 }

--- a/src/TemplateImplements.php
+++ b/src/TemplateImplements.php
@@ -12,8 +12,13 @@ use Attribute;
 )]
 final class TemplateImplements
 {
-    public function __construct(
-        string ...$interfaces
-    ) {
+    /**
+     * @var string[]
+     */
+    public readonly array $interfaces;
+
+    public function __construct(string ...$interfaces)
+    {
+        $this->interfaces = $interfaces;
     }
 }

--- a/src/TemplateUse.php
+++ b/src/TemplateUse.php
@@ -12,8 +12,13 @@ use Attribute;
 )]
 final class TemplateUse
 {
-    public function __construct(
-        string ...$traits
-    ) {
+    /**
+     * @var string[]
+     */
+    public readonly array $traits;
+
+    public function __construct(string ...$traits)
+    {
+        $this->traits = $traits;
     }
 }

--- a/src/Throws.php
+++ b/src/Throws.php
@@ -13,8 +13,13 @@ use Attribute;
 )]
 final class Throws
 {
-    public function __construct(
-        string ...$exceptions
-    ) {
+    /**
+     * @var string[]
+     */
+    public readonly array $exceptions;
+
+    public function __construct(string ...$exceptions)
+    {
+        $this->exceptions = $exceptions;
     }
 }

--- a/src/Type.php
+++ b/src/Type.php
@@ -15,8 +15,7 @@ use Attribute;
 )]
 final class Type
 {
-    public function __construct(
-        string $type
-    ) {
+    public function __construct(public readonly string $type)
+    {
     }
 }

--- a/tests/AssertIfFalseTest.php
+++ b/tests/AssertIfFalseTest.php
@@ -119,8 +119,9 @@ class AssertIfFalseTest extends TestCase
         $asserts = [];
         foreach ($attributes as $attribute) {
             if ($attribute->getName() === AssertIfFalse::class) {
-                $attribute->newInstance();
-                $asserts = array_merge($asserts, $attribute->getArguments());
+                $instance = $attribute->newInstance();
+                assert($instance instanceof AssertIfFalse);
+                $asserts = array_merge($asserts, $instance->params);
             }
         }
 
@@ -129,11 +130,10 @@ class AssertIfFalseTest extends TestCase
             $attributes = $parameter->getAttributes();
             foreach ($attributes as $attribute) {
                 if ($attribute->getName() === AssertIfFalse::class) {
-                    $attribute->newInstance();
-                    $arguments = $attribute->getArguments();
-                    $argument = $arguments[array_key_first($arguments)];
+                    $instance = $attribute->newInstance();
+                    assert($instance instanceof AssertIfFalse);
+                    $argument = $instance->params[array_key_first($instance->params)];
                     $asserts[$parameter->name] = $argument;
-                    ;
                 }
             }
         }

--- a/tests/AssertIfTrueTest.php
+++ b/tests/AssertIfTrueTest.php
@@ -119,8 +119,9 @@ class AssertIfTrueTest extends TestCase
         $asserts = [];
         foreach ($attributes as $attribute) {
             if ($attribute->getName() === AssertIfTrue::class) {
-                $attribute->newInstance();
-                $asserts = array_merge($asserts, $attribute->getArguments());
+                $instance = $attribute->newInstance();
+                assert($instance instanceof AssertIfTrue);
+                $asserts = array_merge($asserts, $instance->params);
             }
         }
 
@@ -129,11 +130,10 @@ class AssertIfTrueTest extends TestCase
             $attributes = $parameter->getAttributes();
             foreach ($attributes as $attribute) {
                 if ($attribute->getName() === AssertIfTrue::class) {
-                    $attribute->newInstance();
-                    $arguments = $attribute->getArguments();
-                    $argument = $arguments[array_key_first($arguments)];
+                    $instance = $attribute->newInstance();
+                    assert($instance instanceof AssertIfTrue);
+                    $argument = $instance->params[array_key_first($instance->params)];
                     $asserts[$parameter->name] = $argument;
-                    ;
                 }
             }
         }

--- a/tests/AssertTest.php
+++ b/tests/AssertTest.php
@@ -108,8 +108,9 @@ class AssertTest extends TestCase
         $asserts = [];
         foreach ($attributes as $attribute) {
             if ($attribute->getName() === Assert::class) {
-                $attribute->newInstance();
-                $asserts = array_merge($asserts, $attribute->getArguments());
+                $instance = $attribute->newInstance();
+                assert($instance instanceof Assert);
+                $asserts = array_merge($asserts, $instance->params);
             }
         }
 
@@ -118,11 +119,10 @@ class AssertTest extends TestCase
             $attributes = $parameter->getAttributes();
             foreach ($attributes as $attribute) {
                 if ($attribute->getName() === Assert::class) {
-                    $attribute->newInstance();
-                    $arguments = $attribute->getArguments();
-                    $argument = $arguments[array_key_first($arguments)];
+                    $instance = $attribute->newInstance();
+                    assert($instance instanceof Assert);
+                    $argument = $instance->params[array_key_first($instance->params)];
                     $asserts[$parameter->name] = $argument;
-                    ;
                 }
             }
         }

--- a/tests/DefineTypeTest.php
+++ b/tests/DefineTypeTest.php
@@ -31,8 +31,9 @@ class DefineTypeTest extends TestCase
         $properties = [];
         foreach ($attributes as $attribute) {
             if ($attribute->getName() === DefineType::class) {
-                $attribute->newInstance();
-                $properties = array_merge($properties, $attribute->getArguments());
+                $instance = $attribute->newInstance();
+                assert($instance instanceof DefineType);
+                $properties = array_merge($properties, $instance->types);
             }
         }
 

--- a/tests/ImportTypeTest.php
+++ b/tests/ImportTypeTest.php
@@ -32,8 +32,9 @@ class ImportTypeTest extends TestCase
         $properties = [];
         foreach ($attributes as $attribute) {
             if ($attribute->getName() === ImportType::class) {
-                $attribute->newInstance();
-                $properties = array_merge($properties, $attribute->getArguments());
+                $instance = $attribute->newInstance();
+                assert($instance instanceof ImportType);
+                $properties = array_merge($properties, $instance->from);
             }
         }
 

--- a/tests/MethodTest.php
+++ b/tests/MethodTest.php
@@ -29,8 +29,9 @@ class MethodTest extends TestCase
         $methods = [];
         foreach ($attributes as $attribute) {
             if ($attribute->getName() === Method::class) {
-                $attribute->newInstance();
-                $methods = array_merge($methods, $attribute->getArguments());
+                $instance = $attribute->newInstance();
+                assert($instance instanceof Method);
+                $methods = array_merge($methods, $instance->methods);
             }
         }
 

--- a/tests/MixinTest.php
+++ b/tests/MixinTest.php
@@ -37,8 +37,9 @@ class MixinTest extends TestCase
         $mixins = [];
         foreach ($attributes as $attribute) {
             if ($attribute->getName() === Mixin::class) {
-                $attribute->newInstance();
-                $mixins = array_merge($mixins, $attribute->getArguments());
+                $instance = $attribute->newInstance();
+                assert($instance instanceof Mixin);
+                $mixins = array_merge($mixins, $instance->classes);
             }
         }
 

--- a/tests/ParamOutTest.php
+++ b/tests/ParamOutTest.php
@@ -115,8 +115,9 @@ class ParamOutTest extends TestCase
         $paramOuts = [];
         foreach ($attributes as $attribute) {
             if ($attribute->getName() === ParamOut::class) {
-                $attribute->newInstance();
-                $paramOuts = array_merge($paramOuts, $attribute->getArguments());
+                $instance = $attribute->newInstance();
+                assert($instance instanceof ParamOut);
+                $paramOuts = array_merge($paramOuts, $instance->params);
             }
         }
 
@@ -125,11 +126,10 @@ class ParamOutTest extends TestCase
             $attributes = $parameter->getAttributes();
             foreach ($attributes as $attribute) {
                 if ($attribute->getName() === ParamOut::class) {
-                    $attribute->newInstance();
-                    $arguments = $attribute->getArguments();
-                    $argument = $arguments[array_key_first($arguments)];
+                    $instance = $attribute->newInstance();
+                    assert($instance instanceof ParamOut);
+                    $argument = $instance->params[array_key_first($instance->params)];
                     $paramOuts[$parameter->name] = $argument;
-                    ;
                 }
             }
         }

--- a/tests/ParamTest.php
+++ b/tests/ParamTest.php
@@ -119,8 +119,9 @@ class ParamTest extends TestCase
         $params = [];
         foreach ($attributes as $attribute) {
             if ($attribute->getName() === Param::class) {
-                $attribute->newInstance();
-                $params = array_merge($params, $attribute->getArguments());
+                $instance = $attribute->newInstance();
+                assert($instance instanceof Param);
+                $params = array_merge($params, $instance->params);
             }
         }
 
@@ -129,11 +130,10 @@ class ParamTest extends TestCase
             $attributes = $parameter->getAttributes();
             foreach ($attributes as $attribute) {
                 if ($attribute->getName() === Param::class) {
-                    $attribute->newInstance();
-                    $arguments = $attribute->getArguments();
-                    $argument = $arguments[array_key_first($arguments)];
+                    $instance = $attribute->newInstance();
+                    assert($instance instanceof Param);
+                    $argument = $instance->params[array_key_first($instance->params)];
                     $params[$parameter->name] = $argument;
-                    ;
                 }
             }
         }

--- a/tests/PropertyReadTest.php
+++ b/tests/PropertyReadTest.php
@@ -31,8 +31,9 @@ class PropertyReadTest extends TestCase
         $properties = [];
         foreach ($attributes as $attribute) {
             if ($attribute->getName() === PropertyRead::class) {
-                $attribute->newInstance();
-                $properties = array_merge($properties, $attribute->getArguments());
+                $instance = $attribute->newInstance();
+                assert($instance instanceof PropertyRead);
+                $properties = array_merge($properties, $instance->properties);
             }
         }
 

--- a/tests/PropertyTest.php
+++ b/tests/PropertyTest.php
@@ -40,8 +40,9 @@ class PropertyTest extends TestCase
         $properties = [];
         foreach ($attributes as $attribute) {
             if ($attribute->getName() === Property::class) {
-                $attribute->newInstance();
-                $properties = array_merge($properties, $attribute->getArguments());
+                $instance = $attribute->newInstance();
+                assert($instance instanceof Property);
+                $properties = array_merge($properties, $instance->properties);
             }
         }
 

--- a/tests/PropertyWriteTest.php
+++ b/tests/PropertyWriteTest.php
@@ -31,8 +31,9 @@ class PropertyWriteTest extends TestCase
         $properties = [];
         foreach ($attributes as $attribute) {
             if ($attribute->getName() === PropertyWrite::class) {
-                $attribute->newInstance();
-                $properties = array_merge($properties, $attribute->getArguments());
+                $instance = $attribute->newInstance();
+                assert($instance instanceof PropertyWrite);
+                $properties = array_merge($properties, $instance->properties);
             }
         }
 

--- a/tests/RequireExtendsTest.php
+++ b/tests/RequireExtendsTest.php
@@ -20,9 +20,9 @@ class RequireExtendsTest extends TestCase
         $extends = '';
         foreach ($attributes as $attribute) {
             if ($attribute->getName() === RequireExtends::class) {
-                $attribute->newInstance();
-                $extends = $attribute->getArguments()[0];
-                assert(is_string($extends));
+                $instance = $attribute->newInstance();
+                assert($instance instanceof RequireExtends);
+                $extends = $instance->class;
             }
         }
 

--- a/tests/RequireImplementsTest.php
+++ b/tests/RequireImplementsTest.php
@@ -26,8 +26,9 @@ class RequireImplementsTest extends TestCase implements RequireTestInterface, Re
         $implements = [];
         foreach ($attributes as $attribute) {
             if ($attribute->getName() === RequireImplements::class) {
-                $attribute->newInstance();
-                $implements = array_merge($implements, $attribute->getArguments());
+                $instance = $attribute->newInstance();
+                assert($instance instanceof RequireImplements);
+                $implements = array_merge($implements, $instance->interfaces);
             }
         }
 

--- a/tests/ReturnsTest.php
+++ b/tests/ReturnsTest.php
@@ -93,9 +93,9 @@ class ReturnsTest extends TestCase
         $returns = '';
         foreach ($attributes as $attribute) {
             if ($attribute->getName() === Returns::class) {
-                $attribute->newInstance();
-                $returns = $attribute->getArguments()[0];
-                assert(is_string($returns));
+                $instance = $attribute->newInstance();
+                assert($instance instanceof Returns);
+                $returns = $instance->type;
             }
         }
 

--- a/tests/SelfOutTest.php
+++ b/tests/SelfOutTest.php
@@ -84,9 +84,9 @@ class SelfOutTest extends TestCase
         $selfOut = '';
         foreach ($attributes as $attribute) {
             if ($attribute->getName() === SelfOut::class) {
-                $attribute->newInstance();
-                $selfOut = $attribute->getArguments()[0];
-                assert(is_string($selfOut));
+                $instance = $attribute->newInstance();
+                assert($instance instanceof SelfOut);
+                $selfOut = $instance->type;
             }
         }
 

--- a/tests/TemplateContravariantTest.php
+++ b/tests/TemplateContravariantTest.php
@@ -34,14 +34,11 @@ class TemplateContravariantTest extends TestCase
         $templates = [];
         foreach ($attributes as $attribute) {
             if ($attribute->getName() === TemplateContravariant::class) {
-                $attribute->newInstance();
-                $templateData = $attribute->getArguments();
-                $templateValue = $templateData[0];
-                assert(is_string($templateValue));
-                if (isset($templateData[1])) {
-                    $className = $templateData[1];
-                    assert(is_string($className));
-                    $templateValue .= ' of ' . $className;
+                $instance = $attribute->newInstance();
+                assert($instance instanceof TemplateContravariant);
+                $templateValue = $instance->name;
+                if ($instance->of !== null) {
+                    $templateValue .= ' of ' . $instance->of;
                 }
                 $templates[] = $templateValue;
             }

--- a/tests/TemplateCovariantTest.php
+++ b/tests/TemplateCovariantTest.php
@@ -34,14 +34,11 @@ class TemplateCovariantTest extends TestCase
         $templates = [];
         foreach ($attributes as $attribute) {
             if ($attribute->getName() === TemplateCovariant::class) {
-                $attribute->newInstance();
-                $templateData = $attribute->getArguments();
-                $templateValue = $templateData[0];
-                assert(is_string($templateValue));
-                if (isset($templateData[1])) {
-                    $className = $templateData[1];
-                    assert(is_string($className));
-                    $templateValue .= ' of ' . $className;
+                $instance = $attribute->newInstance();
+                assert($instance instanceof TemplateCovariant);
+                $templateValue = $instance->name;
+                if ($instance->of !== null) {
+                    $templateValue .= ' of ' . $instance->of;
                 }
                 $templates[] = $templateValue;
             }

--- a/tests/TemplateExtendsTest.php
+++ b/tests/TemplateExtendsTest.php
@@ -21,9 +21,9 @@ class TemplateExtendsTest extends TestCase
         $extends = '';
         foreach ($attributes as $attribute) {
             if ($attribute->getName() === TemplateExtends::class) {
-                $attribute->newInstance();
-                $extends = $attribute->getArguments()[0];
-                assert(is_string($extends));
+                $instance = $attribute->newInstance();
+                assert($instance instanceof TemplateExtends);
+                $extends = $instance->class;
             }
         }
 

--- a/tests/TemplateImplementsTest.php
+++ b/tests/TemplateImplementsTest.php
@@ -45,8 +45,9 @@ class TemplateImplementsTest extends TestCase implements TestInterface, TestInte
         $implements = [];
         foreach ($attributes as $attribute) {
             if ($attribute->getName() === TemplateImplements::class) {
-                $attribute->newInstance();
-                $implements = array_merge($implements, $attribute->getArguments());
+                $instance = $attribute->newInstance();
+                assert($instance instanceof TemplateImplements);
+                $implements = array_merge($implements, $instance->interfaces);
             }
         }
 

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -101,14 +101,11 @@ class TemplateTest extends TestCase
         $templates = [];
         foreach ($attributes as $attribute) {
             if ($attribute->getName() === Template::class) {
-                $attribute->newInstance();
-                $templateData = $attribute->getArguments();
-                $templateValue = $templateData[0];
-                assert(is_string($templateValue));
-                if (isset($templateData[1])) {
-                    $className = $templateData[1];
-                    assert(is_string($className));
-                    $templateValue .= ' of ' . $className;
+                $instance = $attribute->newInstance();
+                assert($instance instanceof Template);
+                $templateValue = $instance->name;
+                if ($instance->of !== null) {
+                    $templateValue .= ' of ' . $instance->of;
                 }
                 $templates[] = $templateValue;
             }

--- a/tests/TemplateUseTest.php
+++ b/tests/TemplateUseTest.php
@@ -47,8 +47,9 @@ class TemplateUseTest extends TestCase
         $uses = [];
         foreach ($attributes as $attribute) {
             if ($attribute->getName() === TemplateUse::class) {
-                $attribute->newInstance();
-                $uses = array_merge($uses, $attribute->getArguments());
+                $instance = $attribute->newInstance();
+                assert($instance instanceof TemplateUse);
+                $uses = array_merge($uses, $instance->traits);
             }
         }
 

--- a/tests/ThrowsTest.php
+++ b/tests/ThrowsTest.php
@@ -85,8 +85,9 @@ class ThrowsTest extends TestCase
         $throwss = [];
         foreach ($attributes as $attribute) {
             if ($attribute->getName() === Throws::class) {
-                $attribute->newInstance();
-                $throwss = array_merge($throwss, $attribute->getArguments());
+                $instance = $attribute->newInstance();
+                assert($instance instanceof Throws);
+                $throwss = array_merge($throwss, $instance->exceptions);
             }
         }
 

--- a/tests/TypeTest.php
+++ b/tests/TypeTest.php
@@ -136,9 +136,9 @@ class TypeTest extends TestCase
         $type = '';
         foreach ($attributes as $attribute) {
             if ($attribute->getName() === Type::class) {
-                $attribute->newInstance();
-                $type = $attribute->getArguments()[0];
-                assert(is_string($type));
+                $instance = $attribute->newInstance();
+                assert($instance instanceof Type);
+                $type = $instance->type;
             }
         }
 


### PR DESCRIPTION
## Summary
- store constructor arguments in readonly properties for attribute classes
- adjust tests to read values from instances instead of using reflection